### PR TITLE
map form files

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -234,22 +234,18 @@ func mapFormFiles(formStruct reflect.Value, form map[string][]*multipart.FileHea
 
 			if numElems > 0 {
 				for i := 0; i < numElems; i++ {
-					header := inputValue[i].Header
-
-					if header.Get("Content-Type") == "application/octet-stream" {
-						file, err := inputValue[i].Open()
-						if err != nil {
-							panic(err)
-						}
-
-						content, err := ioutil.ReadAll(file)
-						if err != nil {
-							panic(err)
-						}
-
-						structField.SetString(string(content))
-						formStruct.Elem().Field(i).Set(structField)
+					file, err := inputValue[i].Open()
+					if err != nil {
+						panic(err)
 					}
+
+					content, err := ioutil.ReadAll(file)
+					if err != nil {
+						panic(err)
+					}
+
+					structField.SetString(string(content))
+					formStruct.Elem().Field(i).Set(structField)
 				}
 			}
 		}


### PR DESCRIPTION
I needed this to map files in a form to strings in a structure so I added the function `mapFormFiles` that does that. It mimics hapi's payload parse.

Disclaimer: I don't know what I'm doing, never used reflect before, don't even know how it works. What I'd like this pull request to do is map a file in the form to some kind of io.Reader in a struct, but in my special case I would also like to accept the same kind of field as JSON string. It also has no idea if the file is a text file or not.

It's probably not ready to be accepted as is, but it's under way.
