### PR TITLE
Form binding now works across embedded structs

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -182,12 +182,18 @@ func validateStruct(errors *Errors, obj interface{}) {
 }
 
 func mapForm(formStruct reflect.Value, form map[string][]string, formfile map[string][]*multipart.FileHeader, errors *Errors) {
-	typ := formStruct.Elem().Type()
+	if formStruct.Kind() == reflect.Ptr {
+		formStruct = formStruct.Elem()
+	}
+	typ := formStruct.Type()
 
 	for i := 0; i < typ.NumField(); i++ {
 		typeField := typ.Field(i)
-		if inputFieldName := typeField.Tag.Get("form"); inputFieldName != "" {
-			structField := formStruct.Elem().Field(i)
+		structField := formStruct.Field(i)
+
+		if typeField.Type.Kind() == reflect.Struct {
+			mapForm(structField, form, formfile, errors)
+		} else if inputFieldName := typeField.Tag.Get("form"); inputFieldName != "" {
 			if !structField.CanSet() {
 				continue
 			}
@@ -201,7 +207,7 @@ func mapForm(formStruct reflect.Value, form map[string][]string, formfile map[st
 					for i := 0; i < numElems; i++ {
 						setWithProperType(sliceOf, inputValue[i], slice.Index(i), inputFieldName, errors)
 					}
-					formStruct.Elem().Field(i).Set(slice)
+					formStruct.Field(i).Set(slice)
 				} else {
 					setWithProperType(typeField.Type.Kind(), inputValue[0], structField, inputFieldName, errors)
 				}

--- a/binding_test.go
+++ b/binding_test.go
@@ -137,8 +137,8 @@ func TestValidate(t *testing.T) {
 		}
 	}
 
-	performValidationTest(&BlogPost{"", "...", 0, 0, []int{}}, handlerMustErr, t)
-	performValidationTest(&BlogPost{"Good Title", "Good content", 0, 0, []int{}}, handlerNoErr, t)
+	performValidationTest(&BlogPost{"", "...", BlogPostMeta{0, 0, []int{}}}, handlerMustErr, t)
+	performValidationTest(&BlogPost{"Good Title", "Good content", BlogPostMeta{0, 0, []int{}}}, handlerNoErr, t)
 
 	performValidationTest(&User{Name: "Jim", Home: Address{"", ""}}, handlerMustErr, t)
 	performValidationTest(&User{Name: "Jim", Home: Address{"required", ""}}, handlerNoErr, t)
@@ -516,12 +516,16 @@ type (
 		Create(test testCase, t *testing.T, index int)
 	}
 
+	BlogPostMeta struct {
+		Views    int   `form:"views" json:"views"`
+		internal int   `form:"-"`
+		Multiple []int `form:"multiple"`
+	}
+
 	BlogPost struct {
-		Title    string `form:"title" json:"title" binding:"required"`
-		Content  string `form:"content" json:"content"`
-		Views    int    `form:"views" json:"views"`
-		internal int    `form:"-"`
-		Multiple []int  `form:"multiple"`
+		Title   string `form:"title" json:"title" binding:"required"`
+		Content string `form:"content" json:"content"`
+		BlogPostMeta
 	}
 
 	BlogSection struct {
@@ -675,7 +679,7 @@ var (
 			"",
 			"",
 			false, // false because POST requests should have a body, not just a query string
-			&BlogPost{Title: "Blog Post Title", Content: "This is the content", Views: 3},
+			&BlogPost{Title: "Blog Post Title", Content: "This is the content", BlogPostMeta: BlogPostMeta{Views: 3}},
 		},
 		{
 			"GET",
@@ -683,7 +687,7 @@ var (
 			"",
 			"",
 			true,
-			&BlogPost{Title: "Blog Post Title", Content: "This is the content", Views: 3, Multiple: []int{5, 10, 15, 20}},
+			&BlogPost{Title: "Blog Post Title", Content: "This is the content", BlogPostMeta: BlogPostMeta{Views: 3, Multiple: []int{5, 10, 15, 20}}},
 		},
 	}
 
@@ -702,7 +706,7 @@ var (
 			"",
 			"multipart/form-data",
 			false,
-			&BlogPost{Title: "Blog Post Title", Views: 3},
+			&BlogPost{Title: "Blog Post Title", BlogPostMeta: BlogPostMeta{Views: 3}},
 		},
 		{
 			"POST",
@@ -710,7 +714,7 @@ var (
 			"",
 			"multipart/form-data",
 			true,
-			&BlogPost{Title: "Blog Post Title", Content: "This is the content", Views: 3, Multiple: []int{5, 10, 15, 20}},
+			&BlogPost{Title: "Blog Post Title", Content: "This is the content", BlogPostMeta: BlogPostMeta{Views: 3, Multiple: []int{5, 10, 15, 20}}},
 		},
 	}
 


### PR DESCRIPTION
This patch allows form binding to work across embedded structs (the standard json package already support this).
