### PR TITLE
add form binding to embedded struct pointer

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -239,7 +239,13 @@ func mapForm(formStruct reflect.Value, form map[string][]string,
 		typeField := typ.Field(i)
 		structField := formStruct.Field(i)
 
-		if typeField.Type.Kind() == reflect.Struct {
+		if typeField.Type.Kind() == reflect.Ptr && typeField.Anonymous {
+			structField.Set(reflect.New(typeField.Type.Elem()))
+			mapForm(structField.Elem(), form, formfile, errors)
+			if reflect.DeepEqual(structField.Elem().Interface(), reflect.Zero(structField.Elem().Type()).Interface()) {
+				structField.Set(reflect.Zero(structField.Type()))
+			}
+		} else if typeField.Type.Kind() == reflect.Struct {
 			mapForm(structField, form, formfile, errors)
 		} else if inputFieldName := typeField.Tag.Get("form"); inputFieldName != "" {
 			if !structField.CanSet() {

--- a/common_test.go
+++ b/common_test.go
@@ -39,6 +39,10 @@ type (
 		unexported  string                  `form:"unexported"`
 	}
 
+	EmbedPerson struct {
+		*Person
+	}
+
 	// The common function signature of the handlers going under test.
 	handlerFunc func(interface{}, ...interface{}) martini.Handler
 


### PR DESCRIPTION
limitation:
1) no validations performed on the embedded struct fields if the pointer
is not binded (similar issue for json binding)
2) only support pointer receiver for the Validator interface for the
embedded pointer, and the Validator will need to check for nil receiver

suggestion:
it might be safer to leave the newed embedded struct as is (without
resetting to nil value) even if nothing is binded for the field,
to overcome the above limitation

Closes #30 
