### PR TITLE
Refactors form mapping into smaller functions for clarity

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -256,14 +256,19 @@ func mapFormField(typeField reflect.StructField,
 		}
 	} else if typeField.Type.Kind() == reflect.Struct {
 		mapForm(structField, form, formfile, errors)
-	} else if inputFieldName := typeField.Tag.Get("form"); inputFieldName != "" {
-		mapFormFieldValue(inputFieldName, typeField, structField, form, formfile, errors)
+	} else {
+		mapFormFieldValue(typeField, structField, form, formfile, errors)
 	}
 }
 
-func mapFormFieldValue(inputFieldName string, typeField reflect.StructField,
+func mapFormFieldValue(typeField reflect.StructField,
 	structField reflect.Value, form map[string][]string,
 	formfile map[string][]*multipart.FileHeader, errors Errors) {
+
+	inputFieldName := typeField.Tag.Get("form")
+	if inputFieldName == "" {
+		return
+	}
 
 	if !structField.CanSet() {
 		return

--- a/binding.go
+++ b/binding.go
@@ -285,6 +285,12 @@ func mapFormFieldValue(inputFieldName string, typeField reflect.StructField,
 		return
 	}
 
+	mapFormFieldMultipart(inputFieldName, structField, formfile, errors)
+}
+
+func mapFormFieldMultipart(inputFieldName string, structField reflect.Value,
+	formfile map[string][]*multipart.FileHeader, errors Errors) {
+
 	inputFile, exists := formfile[inputFieldName]
 	if !exists {
 		return

--- a/binding.go
+++ b/binding.go
@@ -248,6 +248,10 @@ func mapFormField(typeField reflect.StructField,
 	structField reflect.Value, form map[string][]string,
 	formfile map[string][]*multipart.FileHeader, errors Errors) {
 
+	if !structField.CanSet() {
+		return
+	}
+
 	if typeField.Type.Kind() == reflect.Ptr && typeField.Anonymous {
 		structField.Set(reflect.New(typeField.Type.Elem()))
 		mapForm(structField.Elem(), form, formfile, errors)
@@ -256,8 +260,47 @@ func mapFormField(typeField reflect.StructField,
 		}
 	} else if typeField.Type.Kind() == reflect.Struct {
 		mapForm(structField, form, formfile, errors)
+	} else if typeField.Type.Kind() == reflect.Slice {
+		mapFormFieldSlice(typeField, structField, form, formfile, errors)
 	} else {
 		mapFormFieldValue(typeField, structField, form, formfile, errors)
+	}
+}
+
+func mapFormFieldSlice(typeField reflect.StructField,
+	structField reflect.Value, form map[string][]string,
+	formfile map[string][]*multipart.FileHeader, errors Errors) {
+
+	if reflect.TypeOf((*multipart.FileHeader)(nil)) == structField.Type().Elem() {
+		mapFormFieldMultipart(typeField, structField, formfile, errors)
+	} else if structField.Type().Elem().Kind() == reflect.Struct {
+		// TODO: element in slice is struct, iterate all and call mapForm
+	} else {
+		mapFormFieldSliceBuiltin(typeField, structField, form, errors)
+	}
+}
+
+func mapFormFieldSliceBuiltin(typeField reflect.StructField,
+        structField reflect.Value, form map[string][]string, errors Errors) {
+
+	inputFieldName := typeField.Tag.Get("form")
+	if inputFieldName == "" {
+		return
+	}
+
+	inputValue, exists := form[inputFieldName]
+	if !exists {
+		return
+	}
+
+	numElems := len(inputValue)
+	if numElems > 0 {
+		sliceOf := structField.Type().Elem().Kind()
+		slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
+		for elemIdx := 0; elemIdx < numElems; elemIdx++ {
+			setWithProperType(sliceOf, inputValue[elemIdx], slice.Index(elemIdx), inputFieldName, errors)
+		}
+		structField.Set(slice)
 	}
 }
 
@@ -265,36 +308,33 @@ func mapFormFieldValue(typeField reflect.StructField,
 	structField reflect.Value, form map[string][]string,
 	formfile map[string][]*multipart.FileHeader, errors Errors) {
 
+	// handle multipart separately
+	if structField.Type() == reflect.TypeOf((*multipart.FileHeader)(nil)) {
+		mapFormFieldMultipart(typeField, structField, formfile, errors)
+		return
+	}
+
 	inputFieldName := typeField.Tag.Get("form")
 	if inputFieldName == "" {
 		return
 	}
 
-	if !structField.CanSet() {
-		return
-	}
-
 	inputValue, exists := form[inputFieldName]
 	if !exists {
-		mapFormFieldMultipart(inputFieldName, structField, formfile, errors)
 		return
 	}
 
-	numElems := len(inputValue)
-	if structField.Kind() == reflect.Slice && numElems > 0 {
-		sliceOf := structField.Type().Elem().Kind()
-		slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
-		for elemIdx := 0; elemIdx < numElems; elemIdx++ {
-			setWithProperType(sliceOf, inputValue[elemIdx], slice.Index(elemIdx), inputFieldName, errors)
-		}
-		structField.Set(slice)
-	} else {
-		setWithProperType(typeField.Type.Kind(), inputValue[0], structField, inputFieldName, errors)
-	}
+	setWithProperType(typeField.Type.Kind(), inputValue[0], structField, inputFieldName, errors)
 }
 
-func mapFormFieldMultipart(inputFieldName string, structField reflect.Value,
+func mapFormFieldMultipart(typeField reflect.StructField,
+	structField reflect.Value,
 	formfile map[string][]*multipart.FileHeader, errors Errors) {
+
+	inputFieldName := typeField.Tag.Get("form")
+	if inputFieldName == "" {
+		return
+	}
 
 	inputFile, exists := formfile[inputFieldName]
 	if !exists {

--- a/binding.go
+++ b/binding.go
@@ -236,10 +236,9 @@ func mapForm(formStruct reflect.Value, form map[string][]string,
 	if formStruct.Kind() == reflect.Ptr {
 		formStruct = formStruct.Elem()
 	}
-	typ := formStruct.Type()
 
-	for i := 0; i < typ.NumField(); i++ {
-		typeField := typ.Field(i)
+	for i := 0; i < formStruct.Type().NumField(); i++ {
+		typeField := formStruct.Type().Field(i)
 		structField := formStruct.Field(i)
 
 		if typeField.Type.Kind() == reflect.Ptr && typeField.Anonymous {

--- a/binding.go
+++ b/binding.go
@@ -270,22 +270,22 @@ func mapFormFieldValue(inputFieldName string, typeField reflect.StructField,
 	}
 
 	inputValue, exists := form[inputFieldName]
-	if exists {
-		numElems := len(inputValue)
-		if structField.Kind() == reflect.Slice && numElems > 0 {
-			sliceOf := structField.Type().Elem().Kind()
-			slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
-			for elemIdx := 0; elemIdx < numElems; elemIdx++ {
-				setWithProperType(sliceOf, inputValue[elemIdx], slice.Index(elemIdx), inputFieldName, errors)
-			}
-			structField.Set(slice)
-		} else {
-			setWithProperType(typeField.Type.Kind(), inputValue[0], structField, inputFieldName, errors)
-		}
+	if !exists {
+		mapFormFieldMultipart(inputFieldName, structField, formfile, errors)
 		return
 	}
 
-	mapFormFieldMultipart(inputFieldName, structField, formfile, errors)
+	numElems := len(inputValue)
+	if structField.Kind() == reflect.Slice && numElems > 0 {
+		sliceOf := structField.Type().Elem().Kind()
+		slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
+		for elemIdx := 0; elemIdx < numElems; elemIdx++ {
+			setWithProperType(sliceOf, inputValue[elemIdx], slice.Index(elemIdx), inputFieldName, errors)
+		}
+		structField.Set(slice)
+	} else {
+		setWithProperType(typeField.Type.Kind(), inputValue[0], structField, inputFieldName, errors)
+	}
 }
 
 func mapFormFieldMultipart(inputFieldName string, structField reflect.Value,

--- a/binding.go
+++ b/binding.go
@@ -260,8 +260,8 @@ func mapForm(formStruct reflect.Value, form map[string][]string,
 				if structField.Kind() == reflect.Slice && numElems > 0 {
 					sliceOf := structField.Type().Elem().Kind()
 					slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
-					for i := 0; i < numElems; i++ {
-						setWithProperType(sliceOf, inputValue[i], slice.Index(i), inputFieldName, errors)
+					for elemIdx := 0; elemIdx < numElems; elemIdx++ {
+						setWithProperType(sliceOf, inputValue[elemIdx], slice.Index(elemIdx), inputFieldName, errors)
 					}
 					structField.Set(slice)
 				} else {
@@ -278,8 +278,8 @@ func mapForm(formStruct reflect.Value, form map[string][]string,
 			numElems := len(inputFile)
 			if structField.Kind() == reflect.Slice && numElems > 0 && structField.Type().Elem() == fhType {
 				slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
-				for i := 0; i < numElems; i++ {
-					slice.Index(i).Set(reflect.ValueOf(inputFile[i]))
+				for elemIdx := 0; elemIdx < numElems; elemIdx++ {
+					slice.Index(elemIdx).Set(reflect.ValueOf(inputFile[elemIdx]))
 				}
 				structField.Set(slice)
 			} else if structField.Type() == fhType {

--- a/binding.go
+++ b/binding.go
@@ -237,9 +237,9 @@ func mapForm(formStruct reflect.Value, form map[string][]string,
 		formStruct = formStruct.Elem()
 	}
 
-	for i := 0; i < formStruct.Type().NumField(); i++ {
-		typeField := formStruct.Type().Field(i)
-		structField := formStruct.Field(i)
+	for fieldIdx := 0; fieldIdx < formStruct.Type().NumField(); fieldIdx++ {
+		typeField := formStruct.Type().Field(fieldIdx)
+		structField := formStruct.Field(fieldIdx)
 
 		if typeField.Type.Kind() == reflect.Ptr && typeField.Anonymous {
 			structField.Set(reflect.New(typeField.Type.Elem()))

--- a/binding.go
+++ b/binding.go
@@ -6,7 +6,6 @@ package binding
 import (
 	"encoding/json"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -227,130 +226,6 @@ func validateStruct(errors Errors, obj interface{}) Errors {
 		}
 	}
 	return errors
-}
-
-// Takes values from the form data and puts them into a struct
-func mapForm(formStruct reflect.Value, form map[string][]string,
-	formfile map[string][]*multipart.FileHeader, errors Errors) {
-
-	if formStruct.Kind() == reflect.Ptr {
-		formStruct = formStruct.Elem()
-	}
-
-	for i := 0; i < formStruct.Type().NumField(); i++ {
-		typeField := formStruct.Type().Field(i)
-		structField := formStruct.Field(i)
-		mapFormField(typeField, structField, form, formfile, errors)
-	}
-}
-
-func mapFormField(typeField reflect.StructField,
-	structField reflect.Value, form map[string][]string,
-	formfile map[string][]*multipart.FileHeader, errors Errors) {
-
-	if !structField.CanSet() {
-		return
-	}
-
-	if typeField.Type.Kind() == reflect.Ptr && typeField.Anonymous {
-		structField.Set(reflect.New(typeField.Type.Elem()))
-		mapForm(structField.Elem(), form, formfile, errors)
-		if reflect.DeepEqual(structField.Elem().Interface(), reflect.Zero(structField.Elem().Type()).Interface()) {
-			structField.Set(reflect.Zero(structField.Type()))
-		}
-	} else if typeField.Type.Kind() == reflect.Struct {
-		mapForm(structField, form, formfile, errors)
-	} else if typeField.Type.Kind() == reflect.Slice {
-		mapFormFieldSlice(typeField, structField, form, formfile, errors)
-	} else {
-		mapFormFieldValue(typeField, structField, form, formfile, errors)
-	}
-}
-
-func mapFormFieldSlice(typeField reflect.StructField,
-	structField reflect.Value, form map[string][]string,
-	formfile map[string][]*multipart.FileHeader, errors Errors) {
-
-	if reflect.TypeOf((*multipart.FileHeader)(nil)) == structField.Type().Elem() {
-		mapFormFieldMultipart(typeField, structField, formfile, errors)
-	} else if structField.Type().Elem().Kind() == reflect.Struct {
-		// TODO: element in slice is struct, iterate all and call mapForm
-	} else {
-		mapFormFieldSliceBuiltin(typeField, structField, form, errors)
-	}
-}
-
-func mapFormFieldSliceBuiltin(typeField reflect.StructField,
-        structField reflect.Value, form map[string][]string, errors Errors) {
-
-	inputFieldName := typeField.Tag.Get("form")
-	if inputFieldName == "" {
-		return
-	}
-
-	inputValue, exists := form[inputFieldName]
-	if !exists {
-		return
-	}
-
-	numElems := len(inputValue)
-	if numElems > 0 {
-		sliceOf := structField.Type().Elem().Kind()
-		slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
-		for i := 0; i < numElems; i++ {
-			setWithProperType(sliceOf, inputValue[i], slice.Index(i), inputFieldName, errors)
-		}
-		structField.Set(slice)
-	}
-}
-
-func mapFormFieldValue(typeField reflect.StructField,
-	structField reflect.Value, form map[string][]string,
-	formfile map[string][]*multipart.FileHeader, errors Errors) {
-
-	// handle multipart separately
-	if structField.Type() == reflect.TypeOf((*multipart.FileHeader)(nil)) {
-		mapFormFieldMultipart(typeField, structField, formfile, errors)
-		return
-	}
-
-	inputFieldName := typeField.Tag.Get("form")
-	if inputFieldName == "" {
-		return
-	}
-
-	inputValue, exists := form[inputFieldName]
-	if !exists {
-		return
-	}
-
-	setWithProperType(typeField.Type.Kind(), inputValue[0], structField, inputFieldName, errors)
-}
-
-func mapFormFieldMultipart(typeField reflect.StructField,
-	structField reflect.Value,
-	formfile map[string][]*multipart.FileHeader, errors Errors) {
-
-	inputFieldName := typeField.Tag.Get("form")
-	if inputFieldName == "" {
-		return
-	}
-
-	inputFile, exists := formfile[inputFieldName]
-	if !exists {
-		return
-	}
-	fhType := reflect.TypeOf((*multipart.FileHeader)(nil))
-	numElems := len(inputFile)
-	if structField.Kind() == reflect.Slice && numElems > 0 && structField.Type().Elem() == fhType {
-		slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
-		for i := 0; i < numElems; i++ {
-			slice.Index(i).Set(reflect.ValueOf(inputFile[i]))
-		}
-		structField.Set(slice)
-	} else if structField.Type() == fhType {
-		structField.Set(reflect.ValueOf(inputFile[0]))
-	}
 }
 
 // ErrorHandler simply counts the number of errors in the

--- a/binding.go
+++ b/binding.go
@@ -263,7 +263,7 @@ func mapForm(formStruct reflect.Value, form map[string][]string,
 					for i := 0; i < numElems; i++ {
 						setWithProperType(sliceOf, inputValue[i], slice.Index(i), inputFieldName, errors)
 					}
-					formStruct.Field(i).Set(slice)
+					structField.Set(slice)
 				} else {
 					setWithProperType(typeField.Type.Kind(), inputValue[0], structField, inputFieldName, errors)
 				}

--- a/binding.go
+++ b/binding.go
@@ -237,9 +237,9 @@ func mapForm(formStruct reflect.Value, form map[string][]string,
 		formStruct = formStruct.Elem()
 	}
 
-	for fieldIdx := 0; fieldIdx < formStruct.Type().NumField(); fieldIdx++ {
-		typeField := formStruct.Type().Field(fieldIdx)
-		structField := formStruct.Field(fieldIdx)
+	for i := 0; i < formStruct.Type().NumField(); i++ {
+		typeField := formStruct.Type().Field(i)
+		structField := formStruct.Field(i)
 		mapFormField(typeField, structField, form, formfile, errors)
 	}
 }
@@ -297,8 +297,8 @@ func mapFormFieldSliceBuiltin(typeField reflect.StructField,
 	if numElems > 0 {
 		sliceOf := structField.Type().Elem().Kind()
 		slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
-		for elemIdx := 0; elemIdx < numElems; elemIdx++ {
-			setWithProperType(sliceOf, inputValue[elemIdx], slice.Index(elemIdx), inputFieldName, errors)
+		for i := 0; i < numElems; i++ {
+			setWithProperType(sliceOf, inputValue[i], slice.Index(i), inputFieldName, errors)
 		}
 		structField.Set(slice)
 	}
@@ -344,8 +344,8 @@ func mapFormFieldMultipart(typeField reflect.StructField,
 	numElems := len(inputFile)
 	if structField.Kind() == reflect.Slice && numElems > 0 && structField.Type().Elem() == fhType {
 		slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
-		for elemIdx := 0; elemIdx < numElems; elemIdx++ {
-			slice.Index(elemIdx).Set(reflect.ValueOf(inputFile[elemIdx]))
+		for i := 0; i < numElems; i++ {
+			slice.Index(i).Set(reflect.ValueOf(inputFile[i]))
 		}
 		structField.Set(slice)
 	} else if structField.Type() == fhType {

--- a/form_mapping.go
+++ b/form_mapping.go
@@ -1,0 +1,130 @@
+package binding
+
+import(
+	"mime/multipart"
+	"reflect"
+)
+
+// Takes values from the form data and puts them into a struct
+func mapForm(formStruct reflect.Value, form map[string][]string,
+	formfile map[string][]*multipart.FileHeader, errors Errors) {
+
+	if formStruct.Kind() == reflect.Ptr {
+		formStruct = formStruct.Elem()
+	}
+
+	for i := 0; i < formStruct.Type().NumField(); i++ {
+		typeField := formStruct.Type().Field(i)
+		structField := formStruct.Field(i)
+		mapFormField(typeField, structField, form, formfile, errors)
+	}
+}
+
+func mapFormField(typeField reflect.StructField,
+	structField reflect.Value, form map[string][]string,
+	formfile map[string][]*multipart.FileHeader, errors Errors) {
+
+	if !structField.CanSet() {
+		return
+	}
+
+	if typeField.Type.Kind() == reflect.Ptr && typeField.Anonymous {
+		structField.Set(reflect.New(typeField.Type.Elem()))
+		mapForm(structField.Elem(), form, formfile, errors)
+		if reflect.DeepEqual(structField.Elem().Interface(), reflect.Zero(structField.Elem().Type()).Interface()) {
+			structField.Set(reflect.Zero(structField.Type()))
+		}
+	} else if typeField.Type.Kind() == reflect.Struct {
+		mapForm(structField, form, formfile, errors)
+	} else if typeField.Type.Kind() == reflect.Slice {
+		mapFormFieldSlice(typeField, structField, form, formfile, errors)
+	} else {
+		mapFormFieldValue(typeField, structField, form, formfile, errors)
+	}
+}
+
+func mapFormFieldSlice(typeField reflect.StructField,
+	structField reflect.Value, form map[string][]string,
+	formfile map[string][]*multipart.FileHeader, errors Errors) {
+
+	if reflect.TypeOf((*multipart.FileHeader)(nil)) == structField.Type().Elem() {
+		mapFormFieldMultipart(typeField, structField, formfile, errors)
+	} else if structField.Type().Elem().Kind() == reflect.Struct {
+		// TODO: element in slice is struct, iterate all and call mapForm
+	} else {
+		mapFormFieldSliceBuiltin(typeField, structField, form, errors)
+	}
+}
+
+func mapFormFieldSliceBuiltin(typeField reflect.StructField,
+        structField reflect.Value, form map[string][]string, errors Errors) {
+
+	inputFieldName := typeField.Tag.Get("form")
+	if inputFieldName == "" {
+		return
+	}
+
+	inputValue, exists := form[inputFieldName]
+	if !exists {
+		return
+	}
+
+	numElems := len(inputValue)
+	if numElems > 0 {
+		sliceOf := structField.Type().Elem().Kind()
+		slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
+		for i := 0; i < numElems; i++ {
+			setWithProperType(sliceOf, inputValue[i], slice.Index(i), inputFieldName, errors)
+		}
+		structField.Set(slice)
+	}
+}
+
+func mapFormFieldValue(typeField reflect.StructField,
+	structField reflect.Value, form map[string][]string,
+	formfile map[string][]*multipart.FileHeader, errors Errors) {
+
+	// handle multipart separately
+	if structField.Type() == reflect.TypeOf((*multipart.FileHeader)(nil)) {
+		mapFormFieldMultipart(typeField, structField, formfile, errors)
+		return
+	}
+
+	inputFieldName := typeField.Tag.Get("form")
+	if inputFieldName == "" {
+		return
+	}
+
+	inputValue, exists := form[inputFieldName]
+	if !exists {
+		return
+	}
+
+	setWithProperType(typeField.Type.Kind(), inputValue[0], structField, inputFieldName, errors)
+}
+
+func mapFormFieldMultipart(typeField reflect.StructField,
+	structField reflect.Value,
+	formfile map[string][]*multipart.FileHeader, errors Errors) {
+
+	inputFieldName := typeField.Tag.Get("form")
+	if inputFieldName == "" {
+		return
+	}
+
+	inputFile, exists := formfile[inputFieldName]
+	if !exists {
+		return
+	}
+	fhType := reflect.TypeOf((*multipart.FileHeader)(nil))
+	numElems := len(inputFile)
+	if structField.Kind() == reflect.Slice && numElems > 0 && structField.Type().Elem() == fhType {
+		slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
+		for i := 0; i < numElems; i++ {
+			slice.Index(i).Set(reflect.ValueOf(inputFile[i]))
+		}
+		structField.Set(slice)
+	} else if structField.Type() == fhType {
+		structField.Set(reflect.ValueOf(inputFile[0]))
+	}
+}


### PR DESCRIPTION
In preparation for adding support for nested slices of structs I thought I'd refactor the form mapping code that was mostly a single function. Now it's clearly split into smaller functions that take care of the various different cases we care about.

This isn't adding anything just rearranging code for clarity. Enjoy!