### PR TITLE
Pointers support

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -266,7 +266,13 @@ func mapForm(formStruct reflect.Value, form map[string][]string,
 					}
 					formStruct.Field(i).Set(slice)
 				} else {
-					setWithProperType(typeField.Type.Kind(), inputValue[0], structField, inputFieldName, errors)
+					kind := typeField.Type.Kind()
+					if structField.Kind() == reflect.Ptr {
+						structField.Set(reflect.New(typeField.Type.Elem()))
+						structField = structField.Elem()
+						kind = typeField.Type.Elem().Kind()
+					}
+					setWithProperType(kind, inputValue[0], structField, inputFieldName, errors)
 				}
 				continue
 			}

--- a/common_test.go
+++ b/common_test.go
@@ -36,6 +36,7 @@ type (
 		Coauthor    *Person                 `json:"coauthor"`
 		HeaderImage *multipart.FileHeader   `form:"headerImage"`
 		Pictures    []*multipart.FileHeader `form:"picture"`
+		IsActive    *bool                   `form:"is_active"`
 		unexported  string                  `form:"unexported"`
 	}
 

--- a/form_test.go
+++ b/form_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/go-martini/martini"
 )
 
+var addressableTrue bool = true
+
 var formTestCases = []formTestCase{
 	{
 		description:   "Happy path",
@@ -82,6 +84,14 @@ var formTestCases = []formTestCase{
 		payload:       `title=Glorious+Post+Title&id=1&name=Matt+Holt&unexported=foo`,
 		contentType:   formContentType,
 		expected:      BlogPost{Post: Post{Title: "Glorious Post Title"}, Id: 1, Author: Person{Name: "Matt Holt"}},
+	},
+	{
+		description:   "Bool pointer",
+		shouldSucceed: true,
+		payload:       `title=Glorious+Post+Title&id=1&name=Matt+Holt&is_active=true`,
+		contentType:   formContentType,
+		expected:      BlogPost{Post: Post{Title: "Glorious Post Title"}, Id: 1, Author: Person{Name: "Matt Holt"}, IsActive: &addressableTrue},
+		deepEqual:     true,
 	},
 	{
 		description:   "Query string POST",


### PR DESCRIPTION
Pointers of basic types is very useful feature for patching resources

`PATCH example.com/user/1?is_active=true`

```
// After binding saved only IsActive field into DB
type UserForm struct {
    IsActive     *bool   `form:"is_active"`
    OtherStuff *string   `form:"other_stuff"`
}

```
